### PR TITLE
feat: add camera dashboard frontend

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Camera Dashboard</title>
+  </head>
+  <body class="bg-background text-white">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,18 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  roots: ['<rootDir>/src'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
+  },
+  transform: {
+    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: 'tsconfig.jest.json' }]
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/']
+};
+
+export default config;

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "real-time-multi-camera-face-detection-dashboard",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.11.4",
+    "@emotion/styled": "^11.11.5",
+    "@mui/icons-material": "^5.15.19",
+    "@mui/material": "^5.15.19",
+    "@tanstack/react-query": "^5.51.3",
+    "axios": "^1.7.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.23.1"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.5",
+    "@testing-library/react": "^14.3.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.12.12",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@types/react-router-dom": "^5.3.3",
+    "@vitejs/plugin-react": "^4.3.0",
+    "autoprefixer": "^10.4.19",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.3",
+    "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.11"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,31 @@
+import { Navigate, Route, Routes } from 'react-router-dom';
+import { LoginPage } from './pages/LoginPage';
+import { DashboardPage } from './pages/DashboardPage';
+import { useAuth } from './hooks/useAuth';
+
+const RequireAuth: React.FC<{ children: React.ReactElement }> = ({ children }) => {
+  const { isAuthenticated } = useAuth();
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+};
+
+const App: React.FC = () => {
+  return (
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route
+        path="/"
+        element={
+          <RequireAuth>
+            <DashboardPage />
+          </RequireAuth>
+        }
+      />
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  );
+};
+
+export default App;

--- a/src/api/alerts.ts
+++ b/src/api/alerts.ts
@@ -1,0 +1,9 @@
+import apiClient from './client';
+import type { CameraAlert } from '../types';
+
+export const getRecentAlerts = async (cameraId?: string): Promise<CameraAlert[]> => {
+  const { data } = await apiClient.get<CameraAlert[]>('/alerts/recent', {
+    params: cameraId ? { cameraId } : undefined
+  });
+  return data;
+};

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,7 @@
+import apiClient from './client';
+import type { LoginCredentials, LoginResponse } from '../types';
+
+export const login = async (credentials: LoginCredentials): Promise<LoginResponse> => {
+  const { data } = await apiClient.post<LoginResponse>('/auth/login', credentials);
+  return data;
+};

--- a/src/api/cameras.ts
+++ b/src/api/cameras.ts
@@ -1,0 +1,46 @@
+import apiClient from './client';
+import type { Camera, CreateCameraPayload, UpdateCameraPayload } from '../types';
+
+export const getCameras = async (): Promise<Camera[]> => {
+  const { data } = await apiClient.get<Camera[]>('/cameras');
+  return data;
+};
+
+export const createCamera = async (payload: CreateCameraPayload): Promise<Camera> => {
+  const { data } = await apiClient.post<Camera>('/cameras', payload);
+  return data;
+};
+
+export const updateCamera = async (id: string, payload: UpdateCameraPayload): Promise<Camera> => {
+  const { data } = await apiClient.put<Camera>(`/cameras/${id}`, payload);
+  return data;
+};
+
+export const deleteCamera = async (id: string): Promise<void> => {
+  await apiClient.delete(`/cameras/${id}`);
+};
+
+export const startCameraStream = async (id: string): Promise<void> => {
+  await apiClient.post(`/cameras/${id}/stream/start`);
+};
+
+export const stopCameraStream = async (id: string): Promise<void> => {
+  await apiClient.post(`/cameras/${id}/stream/stop`);
+};
+
+export interface WebRTCOfferResponse {
+  sdp: string;
+  type: RTCSdpType;
+}
+
+export const exchangeWebRTCOffer = async (
+  id: string,
+  offer: RTCSessionDescriptionInit
+): Promise<WebRTCOfferResponse> => {
+  const { data } = await apiClient.post<WebRTCOfferResponse>(`/cameras/${id}/webrtc/offer`, offer);
+  return data;
+};
+
+export const sendIceCandidate = async (id: string, candidate: RTCIceCandidateInit): Promise<void> => {
+  await apiClient.post(`/cameras/${id}/webrtc/ice`, candidate);
+};

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,23 @@
+import axios from 'axios';
+import { getEnvVar } from '../utils/env';
+
+const apiClient = axios.create({
+  baseURL: getEnvVar('VITE_API_BASE_URL', 'http://localhost:4000/api'),
+  withCredentials: false
+});
+
+let authToken: string | null = null;
+
+export const setAuthToken = (token: string | null) => {
+  authToken = token;
+};
+
+apiClient.interceptors.request.use((config) => {
+  if (authToken) {
+    config.headers = config.headers ?? {};
+    config.headers.Authorization = `Bearer ${authToken}`;
+  }
+  return config;
+});
+
+export default apiClient;

--- a/src/components/AlertsList.tsx
+++ b/src/components/AlertsList.tsx
@@ -1,0 +1,56 @@
+import {
+  Avatar,
+  Box,
+  Chip,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Typography
+} from '@mui/material';
+import type { CameraAlert } from '../types';
+
+interface AlertsListProps {
+  alerts: CameraAlert[];
+}
+
+export const AlertsList: React.FC<AlertsListProps> = ({ alerts }) => {
+  if (alerts.length === 0) {
+    return (
+      <Box className="flex h-full items-center justify-center py-6">
+        <Typography variant="body2" color="text.secondary">
+          No face detections yet.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <List dense sx={{ maxHeight: 220, overflowY: 'auto' }}>
+      {alerts.map((alert) => (
+        <ListItem key={alert.id} alignItems="flex-start">
+          <ListItemAvatar>
+            <Avatar variant="rounded" src={alert.faceThumbnailUrl} alt="Face thumbnail" />
+          </ListItemAvatar>
+          <ListItemText
+            primary={
+              <Box className="flex items-center justify-between">
+                <Typography variant="subtitle2" color="text.primary">
+                  {new Date(alert.timestamp).toLocaleString()}
+                </Typography>
+                {alert.description ? <Chip label={alert.description} size="small" /> : null}
+              </Box>
+            }
+            secondary={
+              alert.description ? (
+                <Typography variant="body2" color="text.secondary">
+                  {alert.description}
+                </Typography>
+              ) : undefined
+            }
+          />
+        </ListItem>
+      ))}
+    </List>
+  );
+};

--- a/src/components/CameraFormDialog.tsx
+++ b/src/components/CameraFormDialog.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Grid,
+  TextField
+} from '@mui/material';
+import type { Camera, CreateCameraPayload } from '../types';
+
+interface CameraFormDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (values: CreateCameraPayload) => Promise<void> | void;
+  loading?: boolean;
+  initialValues?: Camera | null;
+}
+
+const DEFAULT_VALUES: CreateCameraPayload = {
+  name: '',
+  location: '',
+  rtspUrl: ''
+};
+
+export const CameraFormDialog: React.FC<CameraFormDialogProps> = ({
+  open,
+  onClose,
+  onSubmit,
+  loading = false,
+  initialValues
+}) => {
+  const [values, setValues] = useState<CreateCameraPayload>(DEFAULT_VALUES);
+
+  useEffect(() => {
+    if (initialValues) {
+      setValues({
+        name: initialValues.name,
+        location: initialValues.location,
+        rtspUrl: initialValues.rtspUrl
+      });
+    } else {
+      setValues(DEFAULT_VALUES);
+    }
+  }, [initialValues, open]);
+
+  const handleChange = (field: keyof CreateCameraPayload) => (event: React.ChangeEvent<HTMLInputElement>) => {
+    setValues((prev) => ({ ...prev, [field]: event.target.value }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await onSubmit(values);
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <form onSubmit={handleSubmit}>
+        <DialogTitle>{initialValues ? 'Edit camera' : 'Add camera'}</DialogTitle>
+        <DialogContent>
+          <Box className="mt-2">
+            <Grid container spacing={2}>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  label="Camera name"
+                  fullWidth
+                  required
+                  value={values.name}
+                  onChange={handleChange('name')}
+                />
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  label="Location"
+                  fullWidth
+                  required
+                  value={values.location}
+                  onChange={handleChange('location')}
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  label="RTSP URL"
+                  fullWidth
+                  required
+                  value={values.rtspUrl}
+                  onChange={handleChange('rtspUrl')}
+                />
+              </Grid>
+            </Grid>
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} color="inherit" disabled={loading}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="contained" disabled={loading}>
+            {initialValues ? 'Save changes' : 'Add camera'}
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+};

--- a/src/components/CameraTile.tsx
+++ b/src/components/CameraTile.tsx
@@ -1,0 +1,178 @@
+import {
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  CardHeader,
+  Chip,
+  IconButton,
+  Stack,
+  Tooltip,
+  Typography,
+  Alert as MuiAlert
+} from '@mui/material';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import StopIcon from '@mui/icons-material/Stop';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AlertsList } from './AlertsList';
+import type { Camera, CameraAlert } from '../types';
+import { useWebRTCStream } from '../hooks/useWebRTCStream';
+import { startCameraStream, stopCameraStream } from '../api/cameras';
+
+interface CameraTileProps {
+  camera: Camera;
+  alerts: CameraAlert[];
+  onEdit: (camera: Camera) => void;
+  onDelete: (camera: Camera) => void;
+}
+
+export const CameraTile: React.FC<CameraTileProps> = ({ camera, alerts, onEdit, onDelete }) => {
+  const queryClient = useQueryClient();
+  const { videoRef, start, stop, status, error } = useWebRTCStream(camera.id);
+
+  const startMutation = useMutation({
+    mutationFn: () => startCameraStream(camera.id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['cameras'] });
+    }
+  });
+
+  const stopMutation = useMutation({
+    mutationFn: () => stopCameraStream(camera.id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['cameras'] });
+    }
+  });
+
+  const handleStart = async () => {
+    try {
+      await startMutation.mutateAsync();
+      await start();
+    } catch (startError) {
+      console.error(startError);
+    }
+  };
+
+  const handleStop = async () => {
+    try {
+      await stopMutation.mutateAsync();
+    } finally {
+      stop();
+    }
+  };
+
+  const isLoading = startMutation.isPending || stopMutation.isPending;
+  const isStreaming = status === 'playing' || camera.isStreaming;
+
+  return (
+    <Card elevation={4} sx={{ backgroundColor: 'background.paper', height: '100%' }}>
+      <CardHeader
+        title={
+          <Typography variant="h6" className="truncate">
+            {camera.name}
+          </Typography>
+        }
+        subheader={
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Chip size="small" label={camera.location} color="primary" variant="outlined" />
+            {camera.lastHeartbeatAt ? (
+              <Tooltip title={`Last heartbeat ${new Date(camera.lastHeartbeatAt).toLocaleString()}`}>
+                <Chip size="small" label="Online" color="success" />
+              </Tooltip>
+            ) : (
+              <Chip size="small" label="Heartbeat unavailable" variant="outlined" />
+            )}
+            <Chip
+              size="small"
+              color={status === 'error' ? 'error' : isStreaming ? 'success' : 'default'}
+              label={status === 'connecting' ? 'Connecting' : isStreaming ? 'Streaming' : 'Stopped'}
+            />
+          </Stack>
+        }
+        action={
+          <Stack direction="row" spacing={1}>
+            <Tooltip title="Edit camera">
+              <IconButton color="primary" onClick={() => onEdit(camera)}>
+                <EditIcon />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Delete camera">
+              <IconButton color="error" onClick={() => onDelete(camera)}>
+                <DeleteIcon />
+              </IconButton>
+            </Tooltip>
+          </Stack>
+        }
+      />
+      <CardContent>
+        <Box className="relative aspect-video overflow-hidden rounded-lg bg-slate-900">
+          <video
+            ref={videoRef}
+            className="h-full w-full object-cover"
+            autoPlay
+            playsInline
+            muted
+            poster="https://placehold.co/600x400?text=Initializing"
+          />
+          {status === 'error' && (
+            <Box className="absolute inset-0 flex items-center justify-center bg-black/60">
+              <Stack alignItems="center" spacing={1}>
+                <ErrorOutlineIcon color="error" />
+                <Typography color="error">{error ?? 'Unable to play stream'}</Typography>
+              </Stack>
+            </Box>
+          )}
+        </Box>
+        <Box className="mt-4">
+          <Typography variant="subtitle1" gutterBottom>
+            Recent face detections
+          </Typography>
+          <AlertsList alerts={alerts} />
+        </Box>
+      </CardContent>
+      <CardActions className="flex items-center justify-between px-4 pb-4">
+        <Typography variant="body2" color="text.secondary">
+          RTSP: {camera.rtspUrl}
+        </Typography>
+        <Stack direction="row" spacing={1}>
+          {isStreaming ? (
+            <Button
+              variant="outlined"
+              color="warning"
+              startIcon={<StopIcon />}
+              onClick={handleStop}
+              disabled={isLoading}
+            >
+              Stop stream
+            </Button>
+          ) : (
+            <Button
+              variant="contained"
+              color="primary"
+              startIcon={<PlayArrowIcon />}
+              onClick={handleStart}
+              disabled={isLoading}
+            >
+              Start stream
+            </Button>
+          )}
+        </Stack>
+      </CardActions>
+      {(startMutation.isError || stopMutation.isError) && (
+        <Box className="px-4 pb-4">
+          <MuiAlert severity="error">
+            {startMutation.error instanceof Error
+              ? startMutation.error.message
+              : stopMutation.error instanceof Error
+                ? stopMutation.error.message
+                : 'Stream operation failed'}
+          </MuiAlert>
+        </Box>
+      )}
+    </Card>
+  );
+};

--- a/src/hooks/useAlertsSubscription.ts
+++ b/src/hooks/useAlertsSubscription.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useAuth } from './useAuth';
+import type { CameraAlert } from '../types';
+import { getEnvVar } from '../utils/env';
+
+type ConnectionStatus = 'idle' | 'connecting' | 'open' | 'closed' | 'error';
+
+type AlertsMap = Record<string, CameraAlert[]>;
+
+const DEFAULT_WS_URL = 'ws://localhost:4000/ws';
+
+export const useAlertsSubscription = (cameraIds: string[]) => {
+  const { token } = useAuth();
+  const [status, setStatus] = useState<ConnectionStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [alerts, setAlerts] = useState<AlertsMap>({});
+  const wsRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    // Remove alerts for cameras that are no longer visible
+    setAlerts((current) => {
+      const next: AlertsMap = {};
+      cameraIds.forEach((cameraId) => {
+        if (current[cameraId]) {
+          next[cameraId] = current[cameraId];
+        }
+      });
+      return next;
+    });
+  }, [cameraIds]);
+
+  useEffect(() => {
+    if (!token || cameraIds.length === 0) {
+      setStatus('idle');
+      return;
+    }
+
+    const wsBase = getEnvVar('VITE_WS_BASE_URL', DEFAULT_WS_URL) ?? DEFAULT_WS_URL;
+    const params = new URLSearchParams({ token, cameras: cameraIds.join(',') });
+    const url = `${wsBase.replace(/\\/$/, '')}/alerts?${params.toString()}`;
+
+    setStatus('connecting');
+    setError(null);
+
+    const ws = new WebSocket(url);
+    wsRef.current = ws;
+
+    ws.onopen = () => setStatus('open');
+    ws.onclose = () => setStatus('closed');
+    ws.onerror = () => {
+      setStatus('error');
+      setError('WebSocket connection failed');
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const payload: CameraAlert = JSON.parse(event.data);
+        if (!payload.cameraId) return;
+        setAlerts((current) => {
+          const existing = current[payload.cameraId] ?? [];
+          const next = [payload, ...existing].slice(0, 10);
+          return { ...current, [payload.cameraId]: next };
+        });
+      } catch (messageError) {
+        console.error('Failed to parse alert payload', messageError);
+      }
+    };
+
+    const heartbeat = setInterval(() => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'ping' }));
+      }
+    }, 30000);
+
+    return () => {
+      clearInterval(heartbeat);
+      ws.close();
+      wsRef.current = null;
+    };
+  }, [cameraIds, token]);
+
+  const clearAlerts = useCallback((cameraId: string) => {
+    setAlerts((current) => {
+      const { [cameraId]: _removed, ...rest } = current;
+      return rest;
+    });
+  }, []);
+
+  const aggregatedAlerts = useMemo(() => alerts, [alerts]);
+
+  return {
+    alertsByCamera: aggregatedAlerts,
+    status,
+    error,
+    clearAlerts
+  };
+};

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { AuthContext } from '../providers/AuthProvider';
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};

--- a/src/hooks/useWebRTCStream.ts
+++ b/src/hooks/useWebRTCStream.ts
@@ -1,0 +1,118 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { exchangeWebRTCOffer, sendIceCandidate } from '../api/cameras';
+
+type StreamStatus = 'idle' | 'connecting' | 'playing' | 'stopped' | 'error';
+
+interface UseWebRTCStreamResult {
+  videoRef: React.RefObject<HTMLVideoElement>;
+  start: () => Promise<void>;
+  stop: () => void;
+  status: StreamStatus;
+  error: string | null;
+}
+
+const ICE_SERVERS: RTCIceServer[] = [
+  { urls: 'stun:stun.l.google.com:19302' }
+];
+
+export const useWebRTCStream = (cameraId: string): UseWebRTCStreamResult => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const peerConnectionRef = useRef<RTCPeerConnection | null>(null);
+  const [status, setStatus] = useState<StreamStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const cleanup = useCallback(() => {
+    const peer = peerConnectionRef.current;
+    if (peer) {
+      peer.ontrack = null;
+      peer.onicecandidate = null;
+      peer.onconnectionstatechange = null;
+      peer.close();
+      peerConnectionRef.current = null;
+    }
+    if (videoRef.current) {
+      const mediaStream = videoRef.current.srcObject as MediaStream | null;
+      mediaStream?.getTracks().forEach((track) => track.stop());
+      videoRef.current.srcObject = null;
+    }
+  }, []);
+
+  const stop = useCallback(() => {
+    cleanup();
+    setStatus('stopped');
+  }, [cleanup]);
+
+  const start = useCallback(async () => {
+    if (status === 'playing' || status === 'connecting') return;
+    setStatus('connecting');
+    setError(null);
+
+    try {
+      const peer = new RTCPeerConnection({ iceServers: ICE_SERVERS });
+      peerConnectionRef.current = peer;
+
+      peer.ontrack = (event) => {
+        const [stream] = event.streams;
+        if (videoRef.current && stream) {
+          videoRef.current.srcObject = stream;
+        }
+      };
+
+      peer.onicecandidate = async (event) => {
+        if (event.candidate) {
+          try {
+            await sendIceCandidate(cameraId, event.candidate.toJSON());
+          } catch (candidateError) {
+            console.warn('Failed to send ICE candidate', candidateError);
+          }
+        }
+      };
+
+      peer.onconnectionstatechange = () => {
+        if (!peerConnectionRef.current) return;
+        switch (peer.connectionState) {
+          case 'connected':
+            setStatus('playing');
+            break;
+          case 'failed':
+          case 'disconnected':
+            setStatus('error');
+            setError('Connection lost');
+            cleanup();
+            break;
+          case 'closed':
+            setStatus('stopped');
+            break;
+          default:
+            break;
+        }
+      };
+
+      const offer = await peer.createOffer({ offerToReceiveVideo: true });
+      await peer.setLocalDescription(offer);
+
+      const answer = await exchangeWebRTCOffer(cameraId, offer);
+      await peer.setRemoteDescription(answer);
+
+      setStatus('playing');
+    } catch (err) {
+      console.error(err);
+      setError(err instanceof Error ? err.message : 'Failed to start stream');
+      setStatus('error');
+      cleanup();
+      throw err;
+    }
+  }, [cameraId, cleanup, status]);
+
+  useEffect(() => () => {
+    stop();
+  }, [stop]);
+
+  return {
+    videoRef,
+    start,
+    stop,
+    status,
+    error
+  };
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', sans-serif;
+  background-color: #0f172a;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { CssBaseline, ThemeProvider, createTheme } from '@mui/material';
+import App from './App';
+import './index.css';
+import { AuthProvider } from './providers/AuthProvider';
+
+const queryClient = new QueryClient();
+
+const theme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: { main: '#38bdf8' },
+    background: {
+      default: '#0f172a',
+      paper: '#1e293b'
+    }
+  },
+  typography: {
+    fontFamily: 'Inter, sans-serif'
+  }
+});
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <BrowserRouter>
+          <AuthProvider>
+            <App />
+          </AuthProvider>
+        </BrowserRouter>
+      </ThemeProvider>
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,0 +1,218 @@
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  AppBar,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Container,
+  Grid,
+  IconButton,
+  Stack,
+  Toolbar,
+  Tooltip,
+  Typography
+} from '@mui/material';
+import LogoutIcon from '@mui/icons-material/Logout';
+import AddIcon from '@mui/icons-material/Add';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { CameraTile } from '../components/CameraTile';
+import { CameraFormDialog } from '../components/CameraFormDialog';
+import { createCamera, deleteCamera, getCameras, updateCamera } from '../api/cameras';
+import type { Camera, CameraAlert, CreateCameraPayload } from '../types';
+import { useAuth } from '../hooks/useAuth';
+import { useAlertsSubscription } from '../hooks/useAlertsSubscription';
+import { getRecentAlerts } from '../api/alerts';
+
+export const DashboardPage: React.FC = () => {
+  const { user, logout } = useAuth();
+  const queryClient = useQueryClient();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [editingCamera, setEditingCamera] = useState<Camera | null>(null);
+
+  const camerasQuery = useQuery({
+    queryKey: ['cameras'],
+    queryFn: getCameras
+  });
+
+  const cameras = camerasQuery.data ?? [];
+  const cameraIds = useMemo(() => cameras.map((camera) => camera.id), [cameras]);
+
+  const alertsQuery = useQuery({
+    queryKey: ['alerts', cameraIds],
+    queryFn: () => getRecentAlerts(),
+    enabled: cameraIds.length > 0
+  });
+
+  const { alertsByCamera, status: alertsStatus, error: alertsError } = useAlertsSubscription(cameraIds);
+
+  const createMutation = useMutation({
+    mutationFn: (payload: CreateCameraPayload) => createCamera(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['cameras'] });
+      setIsDialogOpen(false);
+    }
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (payload: { id: string; data: CreateCameraPayload }) => updateCamera(payload.id, payload.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['cameras'] });
+      setIsDialogOpen(false);
+    }
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteCamera(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['cameras'] });
+    }
+  });
+
+  const initialAlertsMap = useMemo(() => {
+    const allAlerts = alertsQuery.data ?? [];
+    return allAlerts.reduce<Record<string, CameraAlert[]>>((accumulator, alert) => {
+      if (!accumulator[alert.cameraId]) {
+        accumulator[alert.cameraId] = [];
+      }
+      accumulator[alert.cameraId].push(alert);
+      return accumulator;
+    }, {});
+  }, [alertsQuery.data]);
+
+  const mergedAlerts = useMemo(() => {
+    const result: Record<string, CameraAlert[]> = {};
+    cameras.forEach((camera) => {
+      const initial = initialAlertsMap[camera.id] ?? [];
+      const live = alertsByCamera[camera.id] ?? [];
+      const combined = [...live, ...initial.filter((alert) => !live.some((liveAlert) => liveAlert.id === alert.id))];
+      result[camera.id] = combined.slice(0, 10);
+    });
+    return result;
+  }, [alertsByCamera, cameras, initialAlertsMap]);
+
+  const handleDialogClose = () => {
+    setIsDialogOpen(false);
+    setEditingCamera(null);
+  };
+
+  const handleCreateOrUpdate = async (payload: CreateCameraPayload) => {
+    if (editingCamera) {
+      await updateMutation.mutateAsync({ id: editingCamera.id, data: payload });
+    } else {
+      await createMutation.mutateAsync(payload);
+    }
+  };
+
+  const handleDeleteCamera = async (camera: Camera) => {
+    const confirmed = window.confirm(`Delete camera "${camera.name}"?`);
+    if (!confirmed) return;
+    await deleteMutation.mutateAsync(camera.id);
+  };
+
+  return (
+    <Box className="min-h-screen bg-slate-950 text-white">
+      <AppBar position="sticky" color="transparent" elevation={0} sx={{ borderBottom: '1px solid rgba(255,255,255,0.1)' }}>
+        <Toolbar className="flex items-center justify-between">
+          <Box>
+            <Typography variant="h5">Live camera dashboard</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Monitor real-time streams and face detection alerts
+            </Typography>
+          </Box>
+          <Stack direction="row" spacing={2} alignItems="center">
+            {alertsStatus === 'open' ? (
+              <Tooltip title="Alerts stream connected">
+                <Chip color="success" size="small" label="Alerts live" />
+              </Tooltip>
+            ) : alertsStatus === 'connecting' ? (
+              <Tooltip title="Connecting to alert stream">
+                <Chip color="warning" size="small" label="Alerts connecting" />
+              </Tooltip>
+            ) : alertsStatus === 'error' ? (
+              <Tooltip title={alertsError ?? 'Alerts unavailable'}>
+                <Chip color="error" size="small" label="Alerts offline" />
+              </Tooltip>
+            ) : null}
+            <Box className="text-right">
+              <Typography variant="subtitle2">{user?.fullName ?? user?.username}</Typography>
+              <Typography variant="caption" color="text.secondary">
+                Operator
+              </Typography>
+            </Box>
+            <Tooltip title="Sign out">
+              <IconButton color="inherit" onClick={logout}>
+                <LogoutIcon />
+              </IconButton>
+            </Tooltip>
+          </Stack>
+        </Toolbar>
+      </AppBar>
+      <Container maxWidth="xl" sx={{ py: 6 }}>
+        <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" alignItems={{ xs: 'stretch', sm: 'center' }} spacing={2} className="mb-6">
+          <Typography variant="h5">Cameras</Typography>
+          <Button
+            variant="contained"
+            startIcon={<AddIcon />}
+            onClick={() => {
+              setEditingCamera(null);
+              setIsDialogOpen(true);
+            }}
+          >
+            Add camera
+          </Button>
+        </Stack>
+
+        {camerasQuery.isLoading ? (
+          <Box className="flex h-64 items-center justify-center">
+            <CircularProgress />
+          </Box>
+        ) : camerasQuery.isError ? (
+          <Alert severity="error">Failed to load cameras. Please retry.</Alert>
+        ) : cameras.length === 0 ? (
+          <Box className="flex h-64 flex-col items-center justify-center space-y-3 rounded-lg border border-dashed border-slate-700 p-8 text-center">
+            <Typography variant="h6">No cameras yet</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Add your first RTSP camera to start streaming and receiving alerts.
+            </Typography>
+            <Button variant="contained" startIcon={<AddIcon />} onClick={() => setIsDialogOpen(true)}>
+              Add camera
+            </Button>
+          </Box>
+        ) : (
+          <Grid container spacing={3}>
+            {cameras.map((camera) => (
+              <Grid key={camera.id} item xs={12} md={6} xl={4}>
+                <CameraTile
+                  camera={camera}
+                  alerts={mergedAlerts[camera.id] ?? []}
+                  onEdit={(selected) => {
+                    setEditingCamera(selected);
+                    setIsDialogOpen(true);
+                  }}
+                  onDelete={handleDeleteCamera}
+                />
+              </Grid>
+            ))}
+          </Grid>
+        )}
+        {alertsStatus === 'error' && alertsError ? (
+          <Box className="mt-6">
+            <Alert severity="warning">{alertsError}</Alert>
+          </Box>
+        ) : null}
+      </Container>
+
+      <CameraFormDialog
+        open={isDialogOpen}
+        onClose={handleDialogClose}
+        onSubmit={handleCreateOrUpdate}
+        initialValues={editingCamera}
+        loading={createMutation.isPending || updateMutation.isPending}
+      />
+    </Box>
+  );
+};
+
+export default DashboardPage;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  Paper,
+  Stack,
+  TextField,
+  Typography
+} from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+export const LoginPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { login, isAuthenticated } = useAuth();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate('/', { replace: true });
+    }
+  }, [isAuthenticated, navigate]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await login({ username, password });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to login');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Container maxWidth="sm" className="min-h-screen flex items-center justify-center">
+      <Paper elevation={8} sx={{ padding: 6, width: '100%' }}>
+        <Typography variant="h4" component="h1" gutterBottom textAlign="center">
+          Camera Dashboard Login
+        </Typography>
+        <Typography variant="body2" color="text.secondary" textAlign="center" className="mb-6">
+          Sign in with your operator credentials to monitor live streams.
+        </Typography>
+        {error ? (
+          <Alert severity="error" className="mb-4">
+            {error}
+          </Alert>
+        ) : null}
+        <Box component="form" onSubmit={handleSubmit} className="space-y-4">
+          <TextField
+            label="Username"
+            fullWidth
+            required
+            value={username}
+            onChange={(event) => setUsername(event.target.value)}
+            autoComplete="username"
+          />
+          <TextField
+            label="Password"
+            fullWidth
+            required
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            type="password"
+            autoComplete="current-password"
+          />
+          <Stack direction="row" justifyContent="flex-end">
+            <Button
+              type="submit"
+              variant="contained"
+              disabled={isSubmitting}
+              startIcon={isSubmitting ? <CircularProgress size={20} /> : null}
+            >
+              {isSubmitting ? 'Signing in…' : 'Sign in'}
+            </Button>
+          </Stack>
+        </Box>
+      </Paper>
+    </Container>
+  );
+};
+
+export default LoginPage;

--- a/src/pages/__tests__/LoginPage.test.tsx
+++ b/src/pages/__tests__/LoginPage.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { LoginPage } from '../LoginPage';
+import { useAuth } from '../../hooks/useAuth';
+import type { AuthContextValue } from '../../providers/AuthProvider';
+
+jest.mock('../../hooks/useAuth', () => ({
+  useAuth: jest.fn()
+}));
+
+describe('LoginPage', () => {
+  const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+  const buildAuthValue = (overrides: Partial<AuthContextValue>): AuthContextValue => ({
+    user: null,
+    token: null,
+    isAuthenticated: false,
+    login: jest.fn().mockResolvedValue(undefined),
+    logout: jest.fn(),
+    ...overrides
+  });
+
+  beforeEach(() => {
+    mockedUseAuth.mockReset();
+  });
+
+  it('submits credentials', async () => {
+    const loginSpy = jest.fn().mockResolvedValue(undefined);
+    mockedUseAuth.mockReturnValue(buildAuthValue({ login: loginSpy }));
+
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByLabelText(/username/i), 'operator');
+    await user.type(screen.getByLabelText(/password/i), 'secret');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    expect(loginSpy).toHaveBeenCalledWith({ username: 'operator', password: 'secret' });
+  });
+});

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -1,0 +1,75 @@
+import { createContext, useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { login as loginRequest } from '../api/auth';
+import { setAuthToken } from '../api/client';
+import type { LoginCredentials, LoginResponse, User } from '../types';
+
+export interface AuthContextValue {
+  user: User | null;
+  token: string | null;
+  isAuthenticated: boolean;
+  login: (credentials: LoginCredentials) => Promise<void>;
+  logout: () => void;
+}
+
+export const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+const AUTH_STORAGE_KEY = 'camera_dashboard_auth';
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const navigate = useNavigate();
+  const [token, setToken] = useState<string | null>(() => {
+    const persisted = localStorage.getItem(AUTH_STORAGE_KEY);
+    if (!persisted) return null;
+    try {
+      const parsed: LoginResponse = JSON.parse(persisted);
+      return parsed.token;
+    } catch (error) {
+      console.error('Failed to parse auth state', error);
+      localStorage.removeItem(AUTH_STORAGE_KEY);
+      return null;
+    }
+  });
+
+  const [user, setUser] = useState<User | null>(() => {
+    const persisted = localStorage.getItem(AUTH_STORAGE_KEY);
+    if (!persisted) return null;
+    try {
+      const parsed: LoginResponse = JSON.parse(persisted);
+      return parsed.user;
+    } catch {
+      return null;
+    }
+  });
+
+  useEffect(() => {
+    setAuthToken(token);
+  }, [token]);
+
+  const login = useCallback(async (credentials: LoginCredentials) => {
+    const response = await loginRequest(credentials);
+    setToken(response.token);
+    setUser(response.user);
+    localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(response));
+    setAuthToken(response.token);
+    navigate('/', { replace: true });
+  }, [navigate]);
+
+  const logout = useCallback(() => {
+    setToken(null);
+    setUser(null);
+    localStorage.removeItem(AUTH_STORAGE_KEY);
+    setAuthToken(null);
+    navigate('/login', { replace: true });
+  }, [navigate]);
+
+  const value = useMemo<AuthContextValue>(() => ({
+    user,
+    token,
+    isAuthenticated: Boolean(token),
+    login,
+    logout
+  }), [login, logout, token, user]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,44 @@
+export interface User {
+  id: string;
+  username: string;
+  fullName?: string;
+}
+
+export interface Camera {
+  id: string;
+  name: string;
+  location: string;
+  rtspUrl: string;
+  isStreaming: boolean;
+  lastHeartbeatAt?: string;
+}
+
+export interface CameraAlert {
+  id: string;
+  cameraId: string;
+  timestamp: string;
+  faceThumbnailUrl: string;
+  description?: string;
+}
+
+export interface CreateCameraPayload {
+  name: string;
+  location: string;
+  rtspUrl: string;
+}
+
+export interface UpdateCameraPayload {
+  name?: string;
+  location?: string;
+  rtspUrl?: string;
+}
+
+export interface LoginCredentials {
+  username: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  token: string;
+  user: User;
+}

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,5 @@
+export const getEnvVar = (key: string, fallback?: string): string | undefined => {
+  const viteEnv = typeof import.meta !== 'undefined' && (import.meta as any)?.env ? (import.meta as any).env[key] : undefined;
+  const nodeEnv = typeof process !== 'undefined' && process.env ? (process.env as Record<string, string | undefined>)[key] : undefined;
+  return (viteEnv as string | undefined) ?? nodeEnv ?? fallback;
+};

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        background: '#0f172a'
+      }
+    }
+  },
+  plugins: []
+};

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["jest", "node"],
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src", "jest.setup.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "composite": false,
+    "baseUrl": "./src",
+    "types": ["vite/client"],
+    "jsx": "react-jsx",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "coverage"]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "lib": ["ES2020", "DOM"],
+    "skipLibCheck": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React TypeScript frontend with Tailwind, MUI, React Query, and Jest tooling
- implement JWT-based auth context, login page, and protected dashboard layout with camera CRUD and streaming controls
- add WebRTC/WebSocket hooks, API layer, reusable components, and a sample Jest test for the login flow

## Testing
- npm install *(fails: registry returned HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ce61d520e4832b8a850680ed3fa726